### PR TITLE
[ISSUE #29] Remove redundant code in NotifyManager.java

### DIFF
--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
@@ -94,7 +94,6 @@ public class NotifyManager {
         defaultMQPushConsumer.setConsumeThreadMax(64);
 
         defaultMQProducer = MqFactory.buildDefaultMQProducer(MixAll.CID_RMQ_SYS_PREFIX + "NotifyRetrySend", serviceConf.getProperties());
-        defaultMQProducer.start();
 
         try {
             defaultMQPushConsumer.start();


### PR DESCRIPTION
fix #29 delete redundant ’defaultMQProducer.start();‘ in NotifyManager.