### PR TITLE
use openssl provider instead of jdk provider to improve performance

### DIFF
--- a/mqtt-cs/pom.xml
+++ b/mqtt-cs/pom.xml
@@ -29,10 +29,6 @@
             <artifactId>netty-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/mqtt-cs/pom.xml
+++ b/mqtt-cs/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>netty-all</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/ssl/SslFactory.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/ssl/SslFactory.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.mqtt.cs.protocol.ssl;
 
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -59,7 +60,7 @@ public class SslFactory {
             InputStream keyStream = new ClassPathResource(KEY_FILE_NAME).getInputStream();
             SslContextBuilder contextBuilder = SslContextBuilder.forServer(certStream, keyStream);
             contextBuilder.clientAuth(ClientAuth.OPTIONAL);
-            contextBuilder.sslProvider(SslProvider.OPENSSL);
+            contextBuilder.sslProvider(OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK);
             if (connectConf.isNeedClientAuth()) {
                 LOG.info("client tls authentication is required.");
                 contextBuilder.clientAuth(ClientAuth.REQUIRE);

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/ssl/SslFactory.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/ssl/SslFactory.java
@@ -59,7 +59,7 @@ public class SslFactory {
             InputStream keyStream = new ClassPathResource(KEY_FILE_NAME).getInputStream();
             SslContextBuilder contextBuilder = SslContextBuilder.forServer(certStream, keyStream);
             contextBuilder.clientAuth(ClientAuth.OPTIONAL);
-            contextBuilder.sslProvider(SslProvider.JDK);
+            contextBuilder.sslProvider(SslProvider.OPENSSL);
             if (connectConf.isNeedClientAuth()) {
                 LOG.info("client tls authentication is required.");
                 contextBuilder.clientAuth(ClientAuth.REQUIRE);

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
                 <version>4.1.43.Final</version>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-boringssl-static</artifactId>
+                <version>2.0.26.Final</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${spring.version}</version>


### PR DESCRIPTION
This pr is to resolve @pingww 's review in [PR-115 Support tls tcp server](https://github.com/apache/rocketmq-mqtt/pull/115). Switch ssl provider to openssl, performance will be better.

link #51 