### PR TITLE
bug fix: change groupId

### DIFF
--- a/meta/src/main/java/org/apache/rocketmq/mqtt/meta/raft/MqttRaftServer.java
+++ b/meta/src/main/java/org/apache/rocketmq/mqtt/meta/raft/MqttRaftServer.java
@@ -78,7 +78,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class MqttRaftServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(MqttRaftServer.class);
 
-    private static final String GROUP_SEQ_NUM_SPLIT = "%";
+    private static final String GROUP_SEQ_NUM_SPLIT = "-";
     @Resource
     private MetaConf metaConf;
 

--- a/meta/src/test/java/org/apache/rocketmq/mqtt/meta/raft/CounterClient.java
+++ b/meta/src/test/java/org/apache/rocketmq/mqtt/meta/raft/CounterClient.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 
 public class CounterClient {
-    private static final String GROUP_SEQ_NUM_SPLIT = "%";
+    private static final String GROUP_SEQ_NUM_SPLIT = "-";
 
     public static void main(final String[] args) throws Exception {
 


### PR DESCRIPTION
groupID should be started with character 'a'-'z' or 'A'-'Z', and followed with numbers, english alphabet, '-' or '_'.