### PR TITLE
fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ For example, set the following parameters to true in broker.conf
 enableLmq = true
 enableMultiDispatch = true
 ```
+### Build Requirements
+The current project requires JDK 1.8.x.  When building on MAC arm64 the recommended JDK 1.8 must be based on 386 architecture or use Maven flag `-Dos.arch=x86_64` when building with Maven.
 
 
 1. Clone


### PR DESCRIPTION
## WHAT
1. Added instructions how to properly build project
2. Added recommendation how to build project on MAC/arm64 architecture

## WHY
Parent project states it supports JDK 1.8 or higher.  While this project based on POM requires 1.8 due to removal of javax.annotations from higher JDK versions
