### PR TITLE
Hot reload ssl certificate

### DIFF
--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/ssl/SslFactory.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/ssl/SslFactory.java
@@ -25,6 +25,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.mqtt.cs.config.ConnectConf;
+import org.apache.rocketmq.srvutil.FileWatchService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
 import javax.net.ssl.SSLEngine;
 
@@ -44,7 +46,9 @@ public class SslFactory {
     @Resource
     private ConnectConf connectConf;
 
-    private SslContext sslContext;
+    private volatile SslContext sslContext;
+
+    private FileWatchService fileWatchService;
 
     @PostConstruct
     private void initSslContext() {
@@ -57,7 +61,8 @@ public class SslFactory {
             File sslKeyFile = new File(connectConf.getSslServerKeyFile());
             String password = connectConf.getSslServerKeyPassword();
 
-            SslContextBuilder contextBuilder = SslContextBuilder.forServer(sslCertFile, sslKeyFile, StringUtils.isBlank(password) ? null : password);
+            SslContextBuilder contextBuilder = SslContextBuilder.forServer(sslCertFile, sslKeyFile,
+                    StringUtils.isBlank(password) ? null : password);
             contextBuilder.clientAuth(ClientAuth.OPTIONAL);
             contextBuilder.sslProvider(OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK);
             if (connectConf.isNeedClientAuth()) {
@@ -68,6 +73,55 @@ public class SslFactory {
             sslContext = contextBuilder.build();
         } catch (IOException e) {
             throw new RuntimeException("failed to initialize ssl context.", e);
+        }
+    }
+
+    @PostConstruct
+    private void onSslCertChanged() {
+        if (!connectConf.isEnableTlsSever()) {
+            return;
+        }
+
+        String[] watchFiles = {connectConf.getSslServerCertFile(), connectConf.getSslServerKeyFile(),
+                connectConf.getSslCaCertFile()};
+
+        FileWatchService.Listener listener = new FileWatchService.Listener() {
+
+            boolean certChanged, keyChanged = false;
+
+            @Override
+            public void onChanged(String path) {
+                if (path.equals(connectConf.getSslCaCertFile())) {
+                    LOG.info("The trust certificate changed, reload the ssl context");
+                    initSslContext();
+                }
+                if (path.equals(connectConf.getSslServerCertFile())) {
+                    certChanged = true;
+                }
+                if (path.equals(connectConf.getSslServerKeyFile())) {
+                    keyChanged = true;
+                }
+                if (certChanged && keyChanged) {
+                    LOG.info("The certificate and private key changed, reload the ssl context");
+                    certChanged = false;
+                    keyChanged = false;
+                    initSslContext();
+                }
+            }
+        };
+
+        try {
+            fileWatchService = new FileWatchService(watchFiles, listener);
+            fileWatchService.start();
+        } catch (Exception e) {
+            LOG.warn("FileWatchService created error, can't load the certificate dynamically");
+        }
+    }
+
+    @PreDestroy
+    private void destroy() {
+        if (this.fileWatchService != null) {
+            this.fileWatchService.shutdown();
         }
     }
 


### PR DESCRIPTION
This PR enables hot reloading of SSL certificates.

Implemented this feature by using `org.apache.rocketmq.srvutil.FileWatchService`,  this service watches files: `connectConf.getSslServerCertFile(), connectConf.getSslServerKeyFile() and connectConf.getSslCaCertFile()`