### PR TITLE
[ISSUE #285] improvement(meta): make RocksDB JNI compatible with apple M1/M2/M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <protoc-gen-grpc-java.version>1.24.0</protoc-gen-grpc-java.version>
         <rpc-grpc-impl.version>1.3.8</rpc-grpc-impl.version>
         <guava.version>32.0.0-jre</guava.version>
-        <jraft-core.version>1.3.11</jraft-core.version>
+        <jraft-core.version>1.3.12</jraft-core.version>
         <netty.version>4.1.43.Final</netty.version>
         <netty.tcnative.version>2.0.26.Final</netty.tcnative.version>
         <netty.quic.version>0.0.62.Final</netty.quic.version>


### PR DESCRIPTION
### Which Issue(s) This PR Fixes
Fix: #285 

### Brief Description
make RocksDB JNI compatible with apple M1/M2/M3

### How Did You Test This Change?
UT