### PR TITLE
[ISSUE #305]feat: Introduce Standalone Mode by Allowing Meta Module Disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ sh mqadmin updateKvConfig -s LMQ -k ALL_FIRST_TOPICS -v {topic1,topic2} -n {name
 sh mqadmin updateKvConfig  -s LMQ -k {topic} -v {topic/+}  -n {namesrv}
 ```
 6. Start Process
+Note: In standalone mode, Only mqtt.sh is needed to start.
 ```shell
 cd bin
 sh meta.sh start

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ For example, set the following parameters to true in broker.conf
 enableLmq = true
 enableMultiDispatch = true
 ```
+
+### Deployment Modes
+RocketMQ-MQTT supports two deployment modes:
+
++ Cluster-Ready Mode (Meta Enabled, Default): This is the default and full-featured mode. It relies on a meta service (based on RocketMQ's KV storage) for dynamic configuration, cluster node discovery, and advanced features like Retain Messages and Will Messages. This mode is suitable for production and high-availability environments.
+
++ Standalone Mode (Meta Disabled): This is a simplified mode designed for single-node deployments or scenarios where advanced features are not required. It operates without any dependency on the meta service, making configuration and deployment much simpler. In this mode, features like Retain Messages and Will Messages are disabled.
+
 ### Build Requirements
 The current project requires JDK 1.8.x.  When building on MAC arm64 the recommended JDK 1.8 must be based on 386 architecture or use Maven flag `-Dos.arch=x86_64` when building with Maven.
 
@@ -43,15 +51,17 @@ cd conf
 ```
 Some important configuration items in the **service.conf** configuration file 
 
-| **Config Key**        | **Instruction**                                               |
-|-----------------------|---------------------------------------------------------------|
-| username              | used for auth                                                 |
-| secretKey             | used for auth                                                 |
-| NAMESRV_ADDR          | specify namesrv address                                       |
-| eventNotifyRetryTopic | notify event retry topic                                      |
-| clientRetryTopic      | client retry topic                                            |
-| metaAddr              | meta all nodes ip:port. Same as membersAddress in meta.config |
-
+| **Config Key**        | **Instruction**                                                                                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| username              | used for auth                                                                                                                    |
+| secretKey             | used for auth                                                                                                                    |
+| NAMESRV_ADDR          | specify namesrv address                                                                                                          |
+| eventNotifyRetryTopic | notify event retry topic                                                                                                         |
+| clientRetryTopic      | client retry topic                                                                                                               |
+| enableMetaModule   	| (Optional) Switch for meta module. Defaults to true. Set to `false` to enable Standalone Mode.                                   |
+| metaAddr              | meta all nodes ip:port. Same as membersAddress in meta.config. **Required when `enableMetaModule` is `true`.**                   |
+| staticFirstTopics     | A comma-separated list of all first-level MQTT topics. E.g., `chat,iot`. **Required when `enableMetaModule` is `false`.**        |
+| localAddress          | The address for the server's internal RPC loopback. `127.0.0.1` is recommended. **Required when `enableMetaModule` is `false`.** |
 
 And some configuration items in the **meta.conf** configuration file
 

--- a/mqtt-common/src/main/java/org/apache/rocketmq/mqtt/common/model/MqttRetainException.java
+++ b/mqtt-common/src/main/java/org/apache/rocketmq/mqtt/common/model/MqttRetainException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.mqtt.common.model;
+
+public class MqttRetainException extends RuntimeException {
+    public MqttRetainException() { }
+
+    public MqttRetainException(String message) {
+        super(message);
+    }
+}

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/config/ConnectConf.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/config/ConnectConf.java
@@ -51,7 +51,6 @@ public class ConnectConf {
     private int exporterPort = 9090;
     private boolean enablePrometheus = false;
     private boolean exportJvmInfo = true;
-    private boolean enableMetaModule = true;
 
     public ConnectConf() throws IOException {
         ClassPathResource classPathResource = new ClassPathResource(CONF_FILE_NAME);
@@ -221,13 +220,5 @@ public class ConnectConf {
 
     public void setExportJvmInfo(boolean exportJvmInfo) {
         this.exportJvmInfo = exportJvmInfo;
-    }
-
-    public boolean isEnableMetaModule() {
-        return enableMetaModule;
-    }
-
-    public void setEnableMetaModule(boolean enableMetaModule) {
-        this.enableMetaModule = enableMetaModule;
     }
 }

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/config/ConnectConf.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/config/ConnectConf.java
@@ -51,6 +51,7 @@ public class ConnectConf {
     private int exporterPort = 9090;
     private boolean enablePrometheus = false;
     private boolean exportJvmInfo = true;
+    private boolean enableMetaModule = true;
 
     public ConnectConf() throws IOException {
         ClassPathResource classPathResource = new ClassPathResource(CONF_FILE_NAME);
@@ -220,5 +221,13 @@ public class ConnectConf {
 
     public void setExportJvmInfo(boolean exportJvmInfo) {
         this.exportJvmInfo = exportJvmInfo;
+    }
+
+    public boolean isEnableMetaModule() {
+        return enableMetaModule;
+    }
+
+    public void setEnableMetaModule(boolean enableMetaModule) {
+        this.enableMetaModule = enableMetaModule;
     }
 }

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/MqttPacketDispatcher.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/MqttPacketDispatcher.java
@@ -39,7 +39,6 @@ import org.apache.rocketmq.mqtt.cs.channel.ChannelException;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelManager;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttConnectHandler;
-import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttConnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttDisconnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttPingHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttPubAckHandler;

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/MqttPacketDispatcher.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/MqttPacketDispatcher.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.codec.mqtt.MqttPubAckMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
@@ -32,9 +33,12 @@ import org.apache.rocketmq.mqtt.common.hook.HookResult;
 import org.apache.rocketmq.mqtt.common.hook.UpstreamHookManager;
 import org.apache.rocketmq.mqtt.common.model.MqttMessageUpContext;
 import org.apache.rocketmq.mqtt.common.util.HostInfo;
+import org.apache.rocketmq.mqtt.cs.channel.ChannelCloseFrom;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelDecodeException;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelException;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
+import org.apache.rocketmq.mqtt.cs.channel.ChannelManager;
+import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttConnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttConnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttDisconnectHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.handler.MqttPingHandler;
@@ -90,6 +94,9 @@ public class MqttPacketDispatcher extends SimpleChannelInboundHandler<MqttMessag
 
     @Resource
     private UpstreamHookManager upstreamHookManager;
+    
+    @Resource
+    private ChannelManager channelManager;
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, MqttMessage msg) throws Exception {
@@ -133,6 +140,14 @@ public class MqttPacketDispatcher extends SimpleChannelInboundHandler<MqttMessag
             if (hookResult == null) {
                 ctx.fireExceptionCaught(new ChannelException("UpstreamHook Result Unknown"));
                 return;
+            }
+
+            if (!hookResult.isSuccess() && msg.fixedHeader().messageType() == MqttMessageType.PUBLISH) {
+                logger.warn("Request (PUBLISH) from client {} was rejected by hook chain. Reason: {}. Closing connection.",
+                        ChannelInfo.getClientId(ctx.channel()), hookResult.getRemark());
+                
+                channelManager.closeConnect(ctx.channel(), ChannelCloseFrom.SERVER, hookResult.getRemark());
+                return; 
             }
             try {
                 _channelRead0(ctx, msg, hookResult);

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/handler/MqttConnectHandler.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/handler/MqttConnectHandler.java
@@ -31,6 +31,7 @@ import org.apache.rocketmq.mqtt.common.model.WillMessage;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelCloseFrom;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelManager;
+import org.apache.rocketmq.mqtt.cs.config.ConnectConf;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.MqttPacketHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.facotry.MqttMessageFactory;
 import org.apache.rocketmq.mqtt.cs.session.loop.SessionLoop;
@@ -51,6 +52,9 @@ public class MqttConnectHandler implements MqttPacketHandler<MqttConnectMessage>
 
     @Resource
     private ChannelManager channelManager;
+
+    @Resource
+    private ConnectConf connectConf;
 
     @Resource
     private SessionLoop sessionLoop;
@@ -111,15 +115,23 @@ public class MqttConnectHandler implements MqttPacketHandler<MqttConnectMessage>
             sessionLoop.loadSession(ChannelInfo.getClientId(channel), channel);
 
             // save will message
-            WillMessage willMessage = null;
             if (variableHeader.isWillFlag()) {
+                if (!connectConf.isEnableMetaModule()) {
+                    String clientId = ChannelInfo.getClientId(channel);
+                    logger.error("Client [{}] trying to set a Will Message, but the meta module is disabled. Connection refused.", clientId);
+                    MqttConnAckMessage connAckMessage = MqttMessageFactory.buildConnAckMessage(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED);
+                    channel.writeAndFlush(connAckMessage);
+                    channelManager.closeConnect(channel, ChannelCloseFrom.SERVER, "Will Message feature is disabled");
+                    return; 
+                }
+
                 if (payload.willTopic() == null || payload.willMessageInBytes() == null) {
                     logger.error("Will message and will topic can not be empty");
                     channelManager.closeConnect(channel, ChannelCloseFrom.SERVER, "Will message and will topic can not be empty");
                     return;
                 }
 
-                willMessage = new WillMessage(payload.willTopic(), payload.willMessageInBytes(), variableHeader.isWillRetain(), variableHeader.willQos());
+                WillMessage willMessage = new WillMessage(payload.willTopic(), payload.willMessageInBytes(), variableHeader.isWillRetain(), variableHeader.willQos());
                 willLoop.addWillMessage(channel, willMessage);
             }
 

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/handler/MqttConnectHandler.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/protocol/mqtt/handler/MqttConnectHandler.java
@@ -31,11 +31,11 @@ import org.apache.rocketmq.mqtt.common.model.WillMessage;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelCloseFrom;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelManager;
-import org.apache.rocketmq.mqtt.cs.config.ConnectConf;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.MqttPacketHandler;
 import org.apache.rocketmq.mqtt.cs.protocol.mqtt.facotry.MqttMessageFactory;
 import org.apache.rocketmq.mqtt.cs.session.loop.SessionLoop;
 import org.apache.rocketmq.mqtt.cs.session.loop.WillLoop;
+import org.apache.rocketmq.mqtt.ds.config.ServiceConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -54,7 +54,7 @@ public class MqttConnectHandler implements MqttPacketHandler<MqttConnectMessage>
     private ChannelManager channelManager;
 
     @Resource
-    private ConnectConf connectConf;
+    private ServiceConf serviceConf;
 
     @Resource
     private SessionLoop sessionLoop;
@@ -116,11 +116,9 @@ public class MqttConnectHandler implements MqttPacketHandler<MqttConnectMessage>
 
             // save will message
             if (variableHeader.isWillFlag()) {
-                if (!connectConf.isEnableMetaModule()) {
+                if (!serviceConf.isEnableMetaModule()) {
                     String clientId = ChannelInfo.getClientId(channel);
                     logger.error("Client [{}] trying to set a Will Message, but the meta module is disabled. Connection refused.", clientId);
-                    MqttConnAckMessage connAckMessage = MqttMessageFactory.buildConnAckMessage(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED);
-                    channel.writeAndFlush(connAckMessage);
                     channelManager.closeConnect(channel, ChannelCloseFrom.SERVER, "Will Message feature is disabled");
                     return; 
                 }

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/session/loop/WillLoop.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/session/loop/WillLoop.java
@@ -29,6 +29,7 @@ import org.apache.rocketmq.mqtt.common.model.StoreResult;
 import org.apache.rocketmq.mqtt.common.model.WillMessage;
 import org.apache.rocketmq.mqtt.common.util.MessageUtil;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
+import org.apache.rocketmq.mqtt.cs.config.ConnectConf;
 import org.apache.rocketmq.mqtt.cs.config.WillLoopConf;
 import org.apache.rocketmq.mqtt.cs.session.infly.MqttMsgId;
 import org.slf4j.Logger;
@@ -63,12 +64,21 @@ public class WillLoop {
     @Resource
     private WillMsgSender willMsgSender;
 
+    @Resource
+    private ConnectConf connectConf;
+
     public void setWillLoopConf(WillLoopConf willLoopConf) {
         this.willLoopConf = willLoopConf;
     }
 
     @PostConstruct
     public void init() {
+
+        if (!connectConf.isEnableMetaModule()) {
+            logger.info("Meta module is disabled, WillLoop will not be initialized.");
+            return; 
+        }
+        
         aliveService.scheduleWithFixedDelay(() -> csLoop(), 15 * 1000, 10 * 1000, TimeUnit.MILLISECONDS);
         aliveService.scheduleWithFixedDelay(() -> masterLoop(), 10 * 1000, 10 * 1000, TimeUnit.MILLISECONDS);
 

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/session/loop/WillLoop.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/session/loop/WillLoop.java
@@ -249,6 +249,11 @@ public class WillLoop {
     }
 
     public void closeConnect(Channel channel, String clientId, String reason) {
+
+        if (!connectConf.isEnableMetaModule()) {     
+            return;
+        }
+
         String ip = IpUtil.getLocalAddressCompatible();
         String willKey = ip + Constants.CTRL_1 + clientId;
         CompletableFuture<byte[]> willMessageFuture = willMsgPersistManager.get(willKey);

--- a/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/session/loop/WillLoop.java
+++ b/mqtt-cs/src/main/java/org/apache/rocketmq/mqtt/cs/session/loop/WillLoop.java
@@ -29,9 +29,9 @@ import org.apache.rocketmq.mqtt.common.model.StoreResult;
 import org.apache.rocketmq.mqtt.common.model.WillMessage;
 import org.apache.rocketmq.mqtt.common.util.MessageUtil;
 import org.apache.rocketmq.mqtt.cs.channel.ChannelInfo;
-import org.apache.rocketmq.mqtt.cs.config.ConnectConf;
 import org.apache.rocketmq.mqtt.cs.config.WillLoopConf;
 import org.apache.rocketmq.mqtt.cs.session.infly.MqttMsgId;
+import org.apache.rocketmq.mqtt.ds.config.ServiceConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -65,7 +65,7 @@ public class WillLoop {
     private WillMsgSender willMsgSender;
 
     @Resource
-    private ConnectConf connectConf;
+    private ServiceConf serviceConf;
 
     public void setWillLoopConf(WillLoopConf willLoopConf) {
         this.willLoopConf = willLoopConf;
@@ -74,7 +74,7 @@ public class WillLoop {
     @PostConstruct
     public void init() {
 
-        if (!connectConf.isEnableMetaModule()) {
+        if (!serviceConf.isEnableMetaModule()) {
             logger.info("Meta module is disabled, WillLoop will not be initialized.");
             return; 
         }
@@ -250,7 +250,7 @@ public class WillLoop {
 
     public void closeConnect(Channel channel, String clientId, String reason) {
 
-        if (!connectConf.isEnableMetaModule()) {     
+        if (!serviceConf.isEnableMetaModule()) {     
             return;
         }
 

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
@@ -46,6 +46,8 @@ public class ServiceConf {
     private String metaAddr;
     private long retainMsgExpire = 3 * 24 * 60 * 60 * 1000L;
 
+    private boolean enableMetaModule = true;
+
     @PostConstruct
     public void init() throws IOException {
         ClassPathResource classPathResource = new ClassPathResource(CONF_FILE_NAME);
@@ -157,5 +159,13 @@ public class ServiceConf {
 
     public void setRetainMsgExpire(long retainMsgExpire) {
         this.retainMsgExpire = retainMsgExpire;
+    }
+
+    public boolean isEnableMetaModule() {
+        return enableMetaModule;
+    }
+
+    public void setEnableMetaModule(boolean enableMetaModule) {
+        this.enableMetaModule = enableMetaModule;
     }
 }

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
@@ -46,8 +46,9 @@ public class ServiceConf {
     private String metaAddr;
     private long retainMsgExpire = 3 * 24 * 60 * 60 * 1000L;
 
-    private String staticFirstTopics;
     private boolean enableMetaModule = true;
+    private String staticFirstTopics;
+    private String localAddress;
 
     @PostConstruct
     public void init() throws IOException {
@@ -182,5 +183,13 @@ public class ServiceConf {
 
     public void setEnableMetaModule(boolean enableMetaModule) {
         this.enableMetaModule = enableMetaModule;
+    }
+
+    public String getLocalAddress() {
+        return localAddress;
+    }
+
+    public void setLocalAddress(String localAddress) {
+        this.localAddress = localAddress;
     }
 }

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
@@ -74,6 +74,9 @@ public class ServiceConf {
             if (StringUtils.isBlank(staticFirstTopics)) {
                 throw new IOException("When meta module is disabled, staticFirstTopics cannot be blank.");
             }
+            if (StringUtils.isBlank(localAddress)) {
+                throw new IOException("When meta module is disabled, localAddress cannnot be blank.");
+            }
         }
     }
 

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/config/ServiceConf.java
@@ -46,6 +46,7 @@ public class ServiceConf {
     private String metaAddr;
     private long retainMsgExpire = 3 * 24 * 60 * 60 * 1000L;
 
+    private String staticFirstTopics;
     private boolean enableMetaModule = true;
 
     @PostConstruct
@@ -64,8 +65,14 @@ public class ServiceConf {
         if (StringUtils.isBlank(eventNotifyRetryTopic)) {
             throw new RemoteException("eventNotifyRetryTopic is blank");
         }
-        if (StringUtils.isBlank(metaAddr)) {
-            throw new RemoteException("metaAddr is blank");
+        if (this.enableMetaModule) {
+            if (StringUtils.isBlank(metaAddr)) {
+                throw new IOException("metaAddr is blank when meta module is enabled");
+            }
+        } else {
+            if (StringUtils.isBlank(staticFirstTopics)) {
+                throw new IOException("When meta module is disabled, staticFirstTopics cannot be blank.");
+            }
         }
     }
 
@@ -159,6 +166,14 @@ public class ServiceConf {
 
     public void setRetainMsgExpire(long retainMsgExpire) {
         this.retainMsgExpire = retainMsgExpire;
+    }
+
+    public String getStaticFirstTopics() {
+        return staticFirstTopics;
+    }
+
+    public void setStaticFirstTopics(String staticFirstTopics) {
+        this.staticFirstTopics = staticFirstTopics;
     }
 
     public boolean isEnableMetaModule() {

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/meta/MetaRpcClient.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/meta/MetaRpcClient.java
@@ -59,6 +59,12 @@ public class MetaRpcClient {
 
     @PostConstruct
     public void init() throws InterruptedException, TimeoutException {
+
+        if (!serviceConf.isEnableMetaModule()) {
+            logger.info("Meta module is disabled, MetaRpcClient will not be initialized.");
+            return; 
+        }
+
         initRpcServer();
         cliClientService = new CliClientServiceImpl();
         cliClientService.init(new CliOptions());

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
@@ -106,15 +106,15 @@ public class NotifyManager {
         }
 
         if (serviceConf.isEnableMetaModule()) {
-                logger.info("Meta module is enabled. Topics will be discovered dynamically.");
-                scheduler = new ScheduledThreadPoolExecutor(1, new ThreadFactoryImpl("Refresh_Notify_Topic_"));
-                scheduler.scheduleWithFixedDelay(() -> {
-                    try {
-                        refresh();
-                    } catch (Exception e) {
-                        logger.error("Error during scheduled topic refresh", e);
-                    }
-                }, 0, 5, TimeUnit.SECONDS);
+            logger.info("Meta module is enabled. Topics will be discovered dynamically.");
+            scheduler = new ScheduledThreadPoolExecutor(1, new ThreadFactoryImpl("Refresh_Notify_Topic_"));
+            scheduler.scheduleWithFixedDelay(() -> {
+                try {
+                    refresh();
+                } catch (Exception e) {
+                    logger.error("Error during scheduled topic refresh", e);
+                }
+            }, 0, 5, TimeUnit.SECONDS);
         } else {
             logger.info("Meta module is disabled. Subscribing to statically configured topics.");
             String staticTopicsConfig = serviceConf.getStaticFirstTopics();

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
@@ -291,13 +291,11 @@ public class NotifyManager {
 
     protected boolean doNotify(String node, Set<MessageEvent> messageEvents) {
         if (serviceConf.isEnableMetaModule()) {
-            // 这个检查的目的是防止向一个刚刚下线的节点发送 RPC，这只在动态的集群（Meta模式）中有意义。
             Set<String> connectorNodes = metaPersistManager.getConnectNodeSet();
             if (connectorNodes == null || connectorNodes.isEmpty()) {
                 return false;
             }
             if (!connectorNodes.contains(node)) {
-                // 节点已不在集群中，认为通知成功（无需再通知）
                 return true;
             }
         }

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
@@ -73,7 +73,6 @@ public class NotifyManager {
     private NettyRemotingClient remotingClient;
     private DefaultMQProducer defaultMQProducer;
 
-
     @Resource
     private ServiceConf serviceConf;
 
@@ -85,6 +84,12 @@ public class NotifyManager {
 
     @PostConstruct
     public void init() throws MQClientException {
+
+        if (!serviceConf.isEnableMetaModule()) {
+            logger.info("Meta module is disabled, NotifyManager will not be initialized.");
+            return; 
+        }
+
         defaultMQPushConsumer = MqFactory.buildDefaultMQPushConsumer(dispatcherConsumerGroup, serviceConf.getProperties(), new Dispatcher());
         defaultMQPushConsumer.setPullInterval(1);
         defaultMQPushConsumer.setConsumeMessageBatchMaxSize(64);

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/notify/NotifyManager.java
@@ -85,11 +85,6 @@ public class NotifyManager {
     @PostConstruct
     public void init() throws MQClientException {
 
-        if (!serviceConf.isEnableMetaModule()) {
-            logger.info("Meta module is disabled, NotifyManager will not be initialized.");
-            return; 
-        }
-
         defaultMQPushConsumer = MqFactory.buildDefaultMQPushConsumer(dispatcherConsumerGroup, serviceConf.getProperties(), new Dispatcher());
         defaultMQPushConsumer.setPullInterval(1);
         defaultMQPushConsumer.setConsumeMessageBatchMaxSize(64);
@@ -99,28 +94,57 @@ public class NotifyManager {
 
         defaultMQProducer = MqFactory.buildDefaultMQProducer(MixAll.CID_RMQ_SYS_PREFIX + "NotifyRetrySend", serviceConf.getProperties());
 
-        try {
-            defaultMQPushConsumer.start();
-            defaultMQProducer.start();
-        } catch (Exception e) {
-            logger.error("", e);
-        }
-
-        scheduler = new ScheduledThreadPoolExecutor(1, new ThreadFactoryImpl("Refresh_Notify_Topic_"));
-        scheduler.scheduleWithFixedDelay(() -> {
-            try {
-                refresh();
-            } catch (Exception e) {
-                logger.error("", e);
-            }
-        }, 0, 5, TimeUnit.SECONDS);
-
         NettyClientConfig config = new NettyClientConfig();
         remotingClient = new NettyRemotingClient(config);
-        remotingClient.start();
+
+        try {
+            defaultMQProducer.start();
+            remotingClient.start();
+        } catch (Exception e) {
+            logger.error("Fatal: NotifyManager failed to start producer or remoting client.", e);
+            throw new MQClientException("Failed to start producer or remoting client", e);
+        }
+
+        if (serviceConf.isEnableMetaModule()) {
+                logger.info("Meta module is enabled. Topics will be discovered dynamically.");
+                scheduler = new ScheduledThreadPoolExecutor(1, new ThreadFactoryImpl("Refresh_Notify_Topic_"));
+                scheduler.scheduleWithFixedDelay(() -> {
+                    try {
+                        refresh();
+                    } catch (Exception e) {
+                        logger.error("Error during scheduled topic refresh", e);
+                    }
+                }, 0, 5, TimeUnit.SECONDS);
+        } else {
+            logger.info("Meta module is disabled. Subscribing to statically configured topics.");
+            String staticTopicsConfig = serviceConf.getStaticFirstTopics();
+
+            if (StringUtils.isNotBlank(staticTopicsConfig)) {
+                String[] topicArray = staticTopicsConfig.split(",");
+                for (String topic : topicArray) {
+                    String trimmedTopic = topic.trim();
+                    if (StringUtils.isNotBlank(trimmedTopic)) {
+                        subscribe(trimmedTopic);
+                        this.topics.add(trimmedTopic);
+                        logger.info("Successfully configured subscription for static topic: {}", trimmedTopic);
+                    }
+                }
+            } else {
+                logger.warn("Meta module is disabled, but 'mqtt.static.first.topics' is not configured. NotifyManager may not receive any application messages.");
+            }
+        }
+
+        try {
+            defaultMQPushConsumer.start();
+            logger.info("NotifyManager's DefaultMQPushConsumer started successfully.");
+        } catch (Exception e) {
+            logger.error("Fatal: NotifyManager failed to start the core message consumer.", e);
+            throw new MQClientException("Failed to start the core message consumer", e);
+        }
     }
 
     private void refresh() throws MQClientException {
+        
         Set<String> tmp = metaPersistManager.getAllFirstTopics();
         logger.info("Notify Manager is refreshing, all first topic is " + tmp);
 
@@ -219,7 +243,18 @@ public class NotifyManager {
 
     public void notifyMessage(Set<MessageEvent> messageEvents) throws
             MQBrokerException, RemotingException, InterruptedException, MQClientException {
-        Set<String> connectorNodes = metaPersistManager.getConnectNodeSet();
+        Set<String> connectorNodes;
+        if (serviceConf.isEnableMetaModule()) {
+            connectorNodes = metaPersistManager.getConnectNodeSet();
+        } else {
+            String localAddress = serviceConf.getLocalAddress();
+            if (StringUtils.isBlank(localAddress)) {
+                logger.error("Meta module is disabled, but 'mqtt.local.address' is not configured. Cannot notify messages.");
+                return; 
+            }
+            connectorNodes = java.util.Collections.singleton(localAddress);
+        }
+
         if (connectorNodes == null || connectorNodes.isEmpty()) {
             throw new RemotingException("No Connect Nodes");
         }
@@ -255,12 +290,16 @@ public class NotifyManager {
     }
 
     protected boolean doNotify(String node, Set<MessageEvent> messageEvents) {
-        Set<String> connectorNodes = metaPersistManager.getConnectNodeSet();
-        if (connectorNodes == null || connectorNodes.isEmpty()) {
-            return false;
-        }
-        if (!connectorNodes.contains(node)) {
-            return true;
+        if (serviceConf.isEnableMetaModule()) {
+            // 这个检查的目的是防止向一个刚刚下线的节点发送 RPC，这只在动态的集群（Meta模式）中有意义。
+            Set<String> connectorNodes = metaPersistManager.getConnectNodeSet();
+            if (connectorNodes == null || connectorNodes.isEmpty()) {
+                return false;
+            }
+            if (!connectorNodes.contains(node)) {
+                // 节点已不在集群中，认为通知成功（无需再通知）
+                return true;
+            }
         }
         try {
             RemotingCommand eventCommand = createMsgEventCommand(messageEvents);

--- a/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/upstream/processor/PublishProcessor.java
+++ b/mqtt-ds/src/main/java/org/apache/rocketmq/mqtt/ds/upstream/processor/PublishProcessor.java
@@ -29,6 +29,7 @@ import org.apache.rocketmq.mqtt.common.facade.WillMsgSender;
 import org.apache.rocketmq.mqtt.common.hook.HookResult;
 import org.apache.rocketmq.mqtt.common.model.Message;
 import org.apache.rocketmq.mqtt.common.model.MqttMessageUpContext;
+import org.apache.rocketmq.mqtt.common.model.MqttRetainException;
 import org.apache.rocketmq.mqtt.common.model.MqttTopic;
 import org.apache.rocketmq.mqtt.common.model.StoreResult;
 import org.apache.rocketmq.mqtt.common.util.MessageUtil;
@@ -67,13 +68,59 @@ public class PublishProcessor implements UpstreamProcessor, WillMsgSender {
 
     @Override
     public CompletableFuture<HookResult> process(MqttMessageUpContext context, MqttMessage mqttMessage) {
-        CompletableFuture<StoreResult> r = put(context, mqttMessage);
-        return r.thenCompose(storeResult -> HookResult.newHookResult(HookResult.SUCCESS, null,
-                JSON.toJSONBytes(storeResult)));
+        CompletableFuture<StoreResult> storeFuture = put(context, mqttMessage);
+
+        CompletableFuture<CompletableFuture<HookResult>> nestedFuture = storeFuture.handle((storeResult, throwable) -> {
+            if (throwable != null) {
+                String remark = "Processing error";
+                Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
+
+                if (cause instanceof MqttRetainException) {
+                    remark = cause.getMessage();
+                } else {
+                    logger.error("Unexpected error in PublishProcessor.put", cause);
+                }
+                return HookResult.newHookResult(HookResult.FAIL, remark, null); 
+            } else {
+                return HookResult.newHookResult(HookResult.SUCCESS, null, JSON.toJSONBytes(storeResult));
+            }
+        });
+        return nestedFuture.thenCompose(innerFuture -> innerFuture);
     }
 
     public CompletableFuture<StoreResult> put(MqttMessageUpContext context, MqttMessage mqttMessage) {
         MqttPublishMessage mqttPublishMessage = (MqttPublishMessage) mqttMessage;
+
+        if (mqttPublishMessage.fixedHeader().isRetain()) {
+            if (!serviceConf.isEnableMetaModule()) {
+                logger.error("Client [{}] on topic [{}] tried to publish a Retain Message, but the meta module is disabled. Rejecting request.",
+                        context.getClientId(), mqttPublishMessage.variableHeader().topicName());
+
+                MqttRetainException exception = new MqttRetainException("Retain Message feature is disabled.");
+                
+                CompletableFuture<StoreResult> failedFuture = new CompletableFuture<>();
+                failedFuture.completeExceptionally(exception);
+                return failedFuture;
+            } else {
+                MqttPublishMessage retainedMqttPublishMessage = mqttPublishMessage.copy();
+                //Change the retained flag of message that will send MQ is 0
+                mqttPublishMessage = MessageUtil.removeRetainedFlag(mqttPublishMessage);
+                //Keep the retained flag of message that will store meta
+                Message metaMessage = MessageUtil.toMessage(retainedMqttPublishMessage);
+                String msgIdForMeta = MessageClientIDSetter.createUniqID(); 
+                long bornTimeForMeta = System.currentTimeMillis();
+                metaMessage.setMsgId(msgIdForMeta);
+                metaMessage.setBornTimestamp(bornTimeForMeta);
+                metaMessage.setEmpty(ByteBufUtil.getBytes(retainedMqttPublishMessage.content()).length == 0);
+                CompletableFuture<Boolean> storeRetainedFuture = retainedPersistManager.storeRetainedMessage(TopicUtils.normalizeTopic(metaMessage.getOriginTopic()), metaMessage);
+                storeRetainedFuture.whenComplete((res, throwable) -> {
+                    if (throwable != null) {
+                        logger.error("Store topic:{} retained message error.{}", metaMessage.getOriginTopic(), throwable);
+                    }
+                });
+            }
+        }
+
         boolean isEmpty = false;
         //deal empty payload
         if (ByteBufUtil.getBytes(mqttPublishMessage.content()).length == 0) {
@@ -88,23 +135,6 @@ public class PublishProcessor implements UpstreamProcessor, WillMsgSender {
         firstTopicManager.checkFirstTopicIfCreated(mqttTopic.getFirstTopic());      // Check the firstTopic is existed
         Set<String> queueNames = wildcardManager.matchQueueSetByMsgTopic(pubTopic, context.getNamespace()); //According to topic to find queue
         long bornTime = System.currentTimeMillis();
-
-        if (mqttPublishMessage.fixedHeader().isRetain()) {
-            MqttPublishMessage retainedMqttPublishMessage = mqttPublishMessage.copy();
-            //Change the retained flag of message that will send MQ is 0
-            mqttPublishMessage = MessageUtil.removeRetainedFlag(mqttPublishMessage);
-            //Keep the retained flag of message that will store meta
-            Message metaMessage = MessageUtil.toMessage(retainedMqttPublishMessage);
-            metaMessage.setMsgId(msgId);
-            metaMessage.setBornTimestamp(bornTime);
-            metaMessage.setEmpty(isEmpty);
-            CompletableFuture<Boolean> storeRetainedFuture = retainedPersistManager.storeRetainedMessage(TopicUtils.normalizeTopic(metaMessage.getOriginTopic()), metaMessage);
-            storeRetainedFuture.whenComplete((res, throwable) -> {
-                if (throwable != null) {
-                    logger.error("Store topic:{} retained message error.{}", metaMessage.getOriginTopic(), throwable);
-                }
-            });
-        }
 
         Message message = MessageUtil.toMessage(mqttPublishMessage);
         message.setMsgId(msgId);


### PR DESCRIPTION
This PR introduces a crucial option to run the RocketMQ-MQTT proxy layer in a configuration that does not depend on an external stateful meta service.

The primary motivation is to simplify deployment and reduce operational overhead for users who do not require stateful features like Retain Messages and Will Messages. By disabling this dependency, users can deploy the stateless MQTT proxy cluster without the need to set up, manage, and operate a separate, Raft-based meta cluster.

### Key Changes
This feature is implemented through a series of coordinated changes across the common, ds, and cs modules:

1. New Configuration Options:

+ enableMetaModule (in service.conf): A boolean switch (true by default) to enable or disable the entire meta module and its dependent features.
+ staticFirstTopics (in service.conf): A comma-separated list of topics, required when enableMetaModule is false.
+ localAddress (in service.conf): The address for internal RPC loopback, required when enableMetaModule is false.


2. Conditional Logic in NotifyManager:

The NotifyManager has been refactored to operate in two modes.When meta is disabled, it subscribes to the topics listed in staticFirstTopics at startup, instead of dynamically refreshing from the meta service. The message notification logic (notifyMessage) is adjusted to perform a local RPC loopback to itself, instead of broadcasting to a cluster of nodes.

3. Feature Gates for will and retain Messages:

To ensure system stability, features dependent on the meta module are now gated by the enableMetaModule switch.
+ Will Messages: The MqttConnectHandler now checks the switch. If a client attempts to set a Will Message while the meta module is disabled, the server will log an error and close the connection.
+ Retain Messages: The PublishProcessor now checks the switch. If a client attempts to publish a message with the retain flag set while the meta module is disabled, the request is actively rejected.

### How to Configure and Test Standalone Mode
+ In service.conf, set enableMetaModule=false.
+ Configure staticFirstTopics with a comma-separated list of all your application's first-level topics (e.g., staticFirstTopics=topicA,iot/devices).
+ Configure localAddress (e.g., localAddress=127.0.0.1).
+ Start the service using only sh mqtt.sh start. The meta.sh process is not needed.
+ To Test Rejection:
Connect a client with a Will Message set. The server should refuse the connection.
With an active connection, publish a message with the retain flag set to true. The server should close the connection.

### Related Issue
fix #305 